### PR TITLE
if self.offspring returns nil, incompatible_parents shouldn't be boolean

### DIFF
--- a/lib/genealogy/alter_methods.rb
+++ b/lib/genealogy/alter_methods.rb
@@ -9,7 +9,7 @@ module Genealogy
       define_method "add_#{parent}" do |relative|
         unless relative.nil?
           raise IncompatibleObjectException, "Both linked objects must be instances of class with genealogy enabled. Got classes #{relative.class} and #{self.genealogy_class}" unless relative.class.respond_to?(:genealogy_enabled)
-          incompatible_parents = self.offspring | self.siblings.to_a | [self] 
+          incompatible_parents = (self.offspring || []) | self.siblings.to_a | [self]
           raise IncompatibleRelationshipException, "#{relative} can't be #{parent} of #{self}" if incompatible_parents.include? relative
           raise WrongSexException, "Can't add a #{relative.sex} #{parent}" unless (parent == :father and relative.is_male?) or (parent == :mother and relative.is_female?)
         end


### PR DESCRIPTION
With 3 items and no genealogy set up, trying to call .add_father or .add_parents bails because:

```
 nil | [] | [self]
```

evaluates to true.

this patch fixes this.
