### PR TITLE
Limiting ancestors by generations

### DIFF
--- a/lib/genealogy/query_methods.rb
+++ b/lib/genealogy/query_methods.rb
@@ -134,7 +134,7 @@ module Genealogy
       if options[:generations]
         generation_count = 0
         generation_ids = parents.compact.map(&:id)
-        while (generation_count < num_generations) && (generation_ids.length > 0)
+        while (generation_count < options[:generations]) && (generation_ids.length > 0)
           next_gen_ids = []
           ids += generation_ids
           until generation_ids.empty?

--- a/lib/genealogy/query_methods.rb
+++ b/lib/genealogy/query_methods.rb
@@ -128,7 +128,8 @@ module Genealogy
 
     # get list of known ancestrors iterateing over parents
     # @param [Hash] options
-    # @return [ActiveRecord::Relation] list of ancestors
+    # @option options [Symbol] generations lets you limit how many generations will be included in the output.
+    # @return [ActiveRecord::Relation] list of ancestors (limited by a number of generations if so indicated)
     def ancestors(options = {})
       ids = []
       if options[:generations]

--- a/spec/genealogy/query_methods_spec.rb
+++ b/spec/genealogy/query_methods_spec.rb
@@ -62,11 +62,19 @@ describe "*** Query methods (based on spec/genealogy/sample_pedigree*.pdf files)
     its(:paternal_grandparents) {is_expected.to match_array [manuel, terry]}
     its(:maternal_grandparents) {is_expected.to match_array [paso, irene]}
     its(:half_siblings) {is_expected.to match_array [ruben, mary, julian, beatrix]}
-    its(:ancestors) {is_expected.to match_array [paul, titty, manuel, terry, paso, irene, tommy, emily, larry, louise, luis, rosa, marcel, bob, jack, alison]}
     its(:uncles) {is_expected.to match_array [mark, rud]}
     its(:maternal_uncles) {is_expected.to match_array [mark, rud]}
     its(:paternal_uncles) {is_expected.to be_empty}
     its(:great_grandparents) {is_expected.to match_array [nil, nil, marcel, nil, jack, alison, tommy, emily]}
+    describe "ancestors" do
+      it {expect(peter.ancestors).to match_array([paul, titty, manuel, terry, paso, irene, tommy, emily, larry, louise, luis, rosa, marcel, bob, jack, alison])}
+      context "with options generations: 1" do
+        specify { expect(peter.ancestors(generations: 1)).to  match_array([paul, titty])}
+      end
+      context "with options generations: 2" do
+        specify { expect(peter.ancestors(generations: 2)).to  match_array([paul, titty, manuel, terry, paso, irene])}
+      end
+    end
     describe "cousins" do
       it { expect(peter.cousins).to match_array([sam, charlie, sue])}
       context "with options lineage: :paternal" do

--- a/spec/genealogy/query_methods_spec.rb
+++ b/spec/genealogy/query_methods_spec.rb
@@ -293,7 +293,18 @@ describe "*** Query methods (based on spec/genealogy/sample_pedigree*.pdf files)
         specify { expect(louise.children(spouse: larry)).to match_array [tommy] }
       end
     end
-    its(:descendants) {is_expected.to match_array [tommy, irene, titty, peter, jack, john, barbara, mary, debby, steve, paso, rud, mark, sam, charlie, sue]}
+    describe "descendants" do
+      specify { expect(louise.descendants).to match_array [tommy, irene, titty, peter, jack, john, barbara, mary, debby, steve, paso, rud, mark, sam, charlie, sue] }
+      context 'with option generations: 0' do
+        specify { expect(louise.descendants(generations: 0)).to match_array []  }
+      end
+      context 'with option generations: 1' do
+        specify { expect(louise.descendants(generations: 1)).to match_array [tommy, jack, debby]  }
+      end
+      context 'with option generations: 2' do
+        specify { expect(louise.descendants(generations: 2)).to match_array [tommy, jack, debby, irene, john, paso]  }
+      end
+    end
     its(:ancestors) {is_expected.to be_empty}
     its(:great_grandchildren) {is_expected.to match_array [titty, rud, mark, barbara]}
     its(:great_grandparents) {is_expected.to match_array [nil, nil, nil, nil, nil, nil, nil, nil]}

--- a/spec/genealogy/query_methods_spec.rb
+++ b/spec/genealogy/query_methods_spec.rb
@@ -68,6 +68,9 @@ describe "*** Query methods (based on spec/genealogy/sample_pedigree*.pdf files)
     its(:great_grandparents) {is_expected.to match_array [nil, nil, marcel, nil, jack, alison, tommy, emily]}
     describe "ancestors" do
       it {expect(peter.ancestors).to match_array([paul, titty, manuel, terry, paso, irene, tommy, emily, larry, louise, luis, rosa, marcel, bob, jack, alison])}
+      context "with options generations: 0" do
+        specify { expect(peter.ancestors(generations: 0)).to  match_array([])}
+      end
       context "with options generations: 1" do
         specify { expect(peter.ancestors(generations: 1)).to  match_array([paul, titty])}
       end


### PR DESCRIPTION
I added logic to count how many generations the ancestors and descendants query methods go back. The tests pass, but I am sure there is a better way to do it, if you think of one, let me know and I'll see what I can do.