### PR TITLE
Least common ancestor

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ Some of them return a single AR object, like `father` and `paternal_grandfather`
 
 Some query methods can take options: `siblings(half: :mother)` returns maternal half-siblings (same mother). `paul.children(spouse: :titty)` returns all individuals that have paul as father and titty as mother.
 
+### Complex Query methods
+Inspired by the [PedHunter](http://www.ncbi.nlm.nih.gov/CBBresearch/Schaffer/pedhunter.html) tool, currently only the `least_common_ancestor`has been started. It returns an *ActiveRecord::Relation* of the first individuals to appear in the family tree of two individuals.
+
 ### Alter methods
 They change the genealogy updating parent external keys of one ore more individuals. The individuals that are actually modified may differ from the receiver: 
 * `peter.add_father(paul)` alters the receiver, peter's *father_id* gets updated

--- a/lib/genealogy.rb
+++ b/lib/genealogy.rb
@@ -3,6 +3,7 @@ require File.join(File.expand_path(File.dirname(__FILE__)), 'genealogy/exception
 require File.join(File.expand_path(File.dirname(__FILE__)), 'genealogy/util_methods')
 require File.join(File.expand_path(File.dirname(__FILE__)), 'genealogy/ineligible_methods')
 require File.join(File.expand_path(File.dirname(__FILE__)), 'genealogy/query_methods')
+require File.join(File.expand_path(File.dirname(__FILE__)), 'genealogy/complex_query_methods')
 require File.join(File.expand_path(File.dirname(__FILE__)), 'genealogy/alter_methods')
 require File.join(File.expand_path(File.dirname(__FILE__)), 'genealogy/current_spouse_methods')
 require File.join(File.expand_path(File.dirname(__FILE__)), 'genealogy/genealogy')

--- a/lib/genealogy/complex_query_methods.rb
+++ b/lib/genealogy/complex_query_methods.rb
@@ -3,5 +3,36 @@ module Genealogy
     extend ActiveSupport::Concern
     include Constants
 
+    def least_common_ancestor(other_person)
+      self_parent_ids = [self.id]
+      other_parent_ids = [other_person.id]
+
+      generation_count = 1
+
+      self_ancestor_records = [self]
+      other_ancestor_records = [other_person]
+
+      while self_parent_ids.length > 0 || other_parent_ids.length > 0
+        self_store = gclass.where(id: self_parent_ids)
+        other_store = gclass.where(id: other_parent_ids)
+
+        self_next_gen = self_store.flat_map(&:parents).compact
+        other_next_gen = other_store.flat_map(&:parents).compact
+
+        self_ancestor_records += self_next_gen
+        other_ancestor_records += other_next_gen
+
+        self_parent_ids = self_next_gen.compact.map(&:id)
+        other_parent_ids = other_next_gen.compact.map(&:id)
+
+        if (self_ancestor_records & other_ancestor_records).compact.length > 0
+          return gclass.where(id: (self_ancestor_records & other_ancestor_records).map(&:id))
+        else
+          generation_count += 1
+        end
+      end
+      gclass.where(id: nil)
+    end
+
   end
 end

--- a/lib/genealogy/complex_query_methods.rb
+++ b/lib/genealogy/complex_query_methods.rb
@@ -4,6 +4,7 @@ module Genealogy
     include Constants
 
     def least_common_ancestor(other_person)
+      raise ArgumentError, "argument must be an instance of the #{gclass} class" unless other_person.is_a? gclass
       self_parent_ids = [self.id]
       other_parent_ids = [other_person.id]
 

--- a/lib/genealogy/complex_query_methods.rb
+++ b/lib/genealogy/complex_query_methods.rb
@@ -1,0 +1,7 @@
+module Genealogy
+  module ComplexQueryMethods
+    extend ActiveSupport::Concern
+    include Constants
+
+  end
+end

--- a/lib/genealogy/complex_query_methods.rb
+++ b/lib/genealogy/complex_query_methods.rb
@@ -14,8 +14,8 @@ module Genealogy
       other_ancestor_record_ids = [other_person.id]
 
       while self_parent_ids.length > 0 || other_parent_ids.length > 0
-        self_next_gen = gclass.select(:father_id, :mother_id).where(id: self_parent_ids).pluck(:father_id, :mother_id).flatten.compact
-        other_next_gen = gclass.select(:father_id, :mother_id).where(id: other_parent_ids).pluck(:father_id, :mother_id).flatten.compact
+        self_next_gen = gclass.where(id: self_parent_ids).pluck(:father_id, :mother_id).flatten.compact
+        other_next_gen = gclass.where(id: other_parent_ids).pluck(:father_id, :mother_id).flatten.compact
 
         self_ancestor_record_ids += self_next_gen
         self_parent_ids = self_next_gen

--- a/lib/genealogy/complex_query_methods.rb
+++ b/lib/genealogy/complex_query_methods.rb
@@ -3,6 +3,12 @@ module Genealogy
     extend ActiveSupport::Concern
     include Constants
 
+    # @return [ActiveRecord::Relation] of the first individual(s) to show up in the ancestors of two given people. 
+    # It moves up one generation at a time for each individual, stopping when there is a shared ancestor id or when there are no more ancestors
+    # If called on two full siblings, it will return both parents, as they appears in the same generation
+    # If called on two half siblings, it will return only the shared parent
+    # If one individual is the ancestor of the other, it will return that individual as the least common shared ancestors
+    # If none are found, it will return an empty AR relation.
     def least_common_ancestor(other_person)
       raise ArgumentError, "argument must be an instance of the #{gclass} class" unless other_person.is_a? gclass
       self_parent_ids = [self.id]

--- a/lib/genealogy/genealogy.rb
+++ b/lib/genealogy/genealogy.rb
@@ -3,26 +3,27 @@ module Genealogy
   extend ActiveSupport::Concern
 
   module ClassMethods
-    
+
     include Genealogy::Constants
 
     # gives to ActiveRecord model geneaogy capabilities. Modules UtilMethods QueryMethods IneligibleMethods AlterMethods and SpouseMethods are included
     # @param [Hash] options
     # @option options [Boolean] current_spouse (false) specifies whether to track or not individual's current spouse
     # @option options [Boolean] perform_validation (true) specifies whether to perform validation or not while altering pedigree that is before updating relatives external keys
-    # @option options [Boolean, Symbol] ineligibility (:pedigree) specifies ineligibility setting. If `false` ineligibility checks will be disabled and you can assign, as a relative, any individuals you want. 
+    # @option options [Boolean, Symbol] ineligibility (:pedigree) specifies ineligibility setting. If `false` ineligibility checks will be disabled and you can assign, as a relative, any individuals you want.
     #   This can be dangerous because you can build nosense loop (in terms of pedigree). If pass one of symbols `:pedigree` or `:pedigree_and_dates` ineligibility checks will be enabled.
-    #   More specifically with `:pedigree` (or `true`) checks will be based on pedigree topography, i.e., ineligible children will include ancestors. With `:pedigree_and_dates` check will also be based on 
+    #   More specifically with `:pedigree` (or `true`) checks will be based on pedigree topography, i.e., ineligible children will include ancestors. With `:pedigree_and_dates` check will also be based on
     #   procreation ages (min and max, male and female) and life expectancy (male and female), i.e. an individual born 200 years before is an ineligible mother
-    # @option options [Hash] limit_ages (min_male_procreation_age:12, max_male_procreation_age:75, min_female_procreation_age:9, max_female_procreation_age:50, max_male_life_expectancy:110, max_female_life_expectancy:110) 
+    # @option options [Hash] limit_ages (min_male_procreation_age:12, max_male_procreation_age:75, min_female_procreation_age:9, max_female_procreation_age:50, max_male_life_expectancy:110, max_female_life_expectancy:110)
     #   specifies one or more limit ages different than defaults
     # @option options [Hash] column_names (sex:'sex', father_id:'father_id', mother_id:'mother_id', current_spouse_id:'current_spouse_id', birth_date:'birth_date', death_date:'death_date') specifies column names to map database individual table
-    # @option options [Array] sex_values (['M','F']) specifies values used in database sex column 
-    # @return [void] 
+    # @option options [Array] sex_values (['M','F']) specifies values used in database sex column
+    # @return [void]
     def has_parents options = {}
 
       include Genealogy::UtilMethods
       include Genealogy::QueryMethods
+      include Genealogy::ComplexQueryMethods
       include Genealogy::IneligibleMethods
       include Genealogy::AlterMethods
       include Genealogy::CurrentSpouseMethods
@@ -31,8 +32,8 @@ module Genealogy
 
       # keep track of the original extend class to prevent wrong scopes in query method in case of STI
       class_attribute :gclass, instance_writer: false
-      self.gclass = self 
-      
+      self.gclass = self
+
       class_attribute :ineligibility_level, instance_accessor: false
       self.ineligibility_level = case options[:ineligibility]
       when :pedigree
@@ -77,7 +78,7 @@ module Genealogy
       self.sex_values = options[:sex_values] || DEFAULTS[:sex_values]
       self.sex_male_value = self.sex_values.first
       self.sex_female_value = self.sex_values.last
-      
+
       # validation
       validates_presence_of :sex
       validates_format_of :sex, with: /[#{sex_values.join}]/

--- a/spec/genealogy/complex_query_methods_spec.rb
+++ b/spec/genealogy/complex_query_methods_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe "*** Complex Query methods (based on spec/genealogy/sample_pedigree*.pdf files) *** ", :done, :query do
+  before { @model = get_test_model({current_spouse: true})}
+
+
+  describe "peter" do
+    subject {peter}
+    describe "least common ancestor" do
+      context "with steve" do
+        specify { expect(peter.least_common_ancestor(steve)).to match_array([paul, titty])}
+      end
+      context "with sue" do
+        specify { expect(peter.least_common_ancestor(sue)).to match_array([irene, paso])}
+      end
+      context "with mary" do
+        specify { expect(peter.least_common_ancestor(sue)).to match_array([jack, alison])}
+      end
+    end
+  end
+end

--- a/spec/genealogy/complex_query_methods_spec.rb
+++ b/spec/genealogy/complex_query_methods_spec.rb
@@ -2,19 +2,43 @@ require 'spec_helper'
 
 describe "*** Complex Query methods (based on spec/genealogy/sample_pedigree*.pdf files) *** ", :done, :query do
   before { @model = get_test_model({current_spouse: true})}
-
+  include_context "pedigree exists"
 
   describe "peter" do
     subject {peter}
     describe "least common ancestor" do
+      context "with mary" do
+        specify { expect(peter.least_common_ancestor(mary)).to match_array([paul])}
+      end
       context "with steve" do
         specify { expect(peter.least_common_ancestor(steve)).to match_array([paul, titty])}
       end
       context "with sue" do
         specify { expect(peter.least_common_ancestor(sue)).to match_array([irene, paso])}
       end
+      context "with michelle" do
+        specify { expect(peter.least_common_ancestor(michelle)).to match_array([])}
+      end
+      context "with jack" do
+        specify { expect(peter.least_common_ancestor(jack)).to match_array([jack])}
+      end
+      context "with john" do
+        specify { expect(peter.least_common_ancestor(john)).to match_array([jack, alison])}
+      end
+    end
+  end
+
+  describe "irene" do
+    subject {irene}
+    describe "least common ancestor" do
       context "with mary" do
-        specify { expect(peter.least_common_ancestor(sue)).to match_array([jack, alison])}
+        specify { expect(irene.least_common_ancestor(mary)).to match_array([louise])}
+      end
+      context "with paso" do
+        specify { expect(irene.least_common_ancestor(paso)).to match_array([louise])}
+      end
+      context "with rosa" do
+        specify { expect(irene.least_common_ancestor(rosa)).to match_array([rosa])}
       end
     end
   end

--- a/spec/genealogy/complex_query_methods_spec.rb
+++ b/spec/genealogy/complex_query_methods_spec.rb
@@ -40,6 +40,9 @@ describe "*** Complex Query methods (based on spec/genealogy/sample_pedigree*.pd
       context "with rosa" do
         specify { expect(irene.least_common_ancestor(rosa)).to match_array([rosa])}
       end
+      context "with bad input" do
+        specify { expect{irene.least_common_ancestor('17')}.to raise_error(ArgumentError)}
+      end
     end
   end
 end


### PR DESCRIPTION
I added the start of complex query methods from PedHunter, a basic implementation of finding least common ancestors.

I am not sure it is the best way, but it is functional. If you think it should be done better, I can do some more research. It currently only returns the ancestor, but not the path from the individuals to the least common ancestors as discussed on PedHunter. Once the path is discovered, this can also return how two individuals are related..such as "grandchild", "second-cousin", "first cousin once removed", etc.

I you would rather wait on this request until I can create a system that returns not only the ancestor but also at least the path between the two people, I can do that no problem. 